### PR TITLE
Add HOMEPAGE and HOMEPAGE_TITLE environment vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ mkdir ~/wiki/img
 $$x_{1,2} = \frac{-b ± \sqrt{b^2 - 4 a c}}{2a}$$
 ## Homepage
 
-The homepage is default the "homepage.md" file, this can't be changed. If this file doesn't exist create it in de wiki folder.
+The homepage is defaulted to the "homepage.md" file. If you want to use a different file, you can specify the file to use for the homepage with the environment variable `HOMEPAGE` as well as the title with `HOMEPAGE_TITLE`.
 
 ## Uploaded images
 

--- a/wiki.py
+++ b/wiki.py
@@ -11,6 +11,8 @@ import os
 import re
 import uuid
 
+HOMEPAGE = os.getenv('HOMEPAGE', "homepage.md")
+HOMEPAGE_TITLE = os.getenv('HOMEPAGE_TITLE', "homepage")
 WIKI_DATA = os.getenv('WIKI_DATA', "wiki")
 IMAGES_ROUTE = os.getenv('IMAGES_ROUTE', 'img')
 UPLOAD_FOLDER = WIKI_DATA + '/' + IMAGES_ROUTE
@@ -106,7 +108,7 @@ def list_wiki(folderpath):
 
             folder = root[len(WIKI_DATA + "/"):]
             if folder == "":
-                if item == "homepage.md":
+                if item == HOMEPAGE:
                     continue
                 url = os.path.splitext(root[len(WIKI_DATA + "/"):] + "/" + item)[0]
             else:
@@ -179,7 +181,7 @@ def index():
         app.logger.info("homepage displaying")
         try:
             html = pypandoc.convert_file(
-                os.path.join(WIKI_DATA, "homepage.md"), "html5", format='md', extra_args=["--mathjax"],
+                os.path.join(WIKI_DATA, HOMEPAGE), "html5", format='md', extra_args=["--mathjax"],
                 filters=['pandoc-xnos'])
 
         except Exception as a:
@@ -208,9 +210,9 @@ def edit_homepage():
 
         return redirect(url_for("file_page", file_page=page_name))
     else:
-        with open(os.path.join(WIKI_DATA, 'homepage.md'), 'r', encoding="utf-8") as f:
+        with open(os.path.join(WIKI_DATA, HOMEPAGE), 'r', encoding="utf-8") as f:
             content = f.read()
-        return render_template("new.html", content=content, title="homepage", upload_path=IMAGES_ROUTE,
+        return render_template("new.html", content=content, title=HOMEPAGE_TITLE, upload_path=IMAGES_ROUTE,
                                system=SYSTEM_SETTINGS)
 
 


### PR DESCRIPTION
Feel free to deny the merge if you want! This was an option I wanted and thought it may be good to submit a PR.

Added option to change the homepage file and title of that file with an environment variable. If none is set, it'll default back to the original settings `homepage.md` and `homepage` for the title.