### PR TITLE
Fix docker image + CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,118 @@
+name: docker
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      wikmd_tag: ${{ steps.meta.outputs.tags }}
+    strategy:
+      matrix:
+        architecture:
+          - linux/amd64
+          # - linux/arm64
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            linbreux/wikmd
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{major}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Check docker image tag
+        run: |
+          echo "Creating Docker image ${{ steps.meta.outputs.tags }}"
+
+      - name: Build & export
+        uses: docker/build-push-action@v3
+        with:
+          file: docker/Dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          outputs: type=docker,dest=/tmp/wikmd.tar
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: wikmd
+          path: /tmp/wikmd.tar
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: wikmd
+          path: /tmp
+
+      - name: Load image
+        run: |
+          docker load --input /tmp/wikmd.tar
+          docker image ls -a
+
+      # Start a default Wikmd container
+      - name: Start wikmd
+        run: docker run -d --name wikmd -p 5000:5000 ${{ needs.build.outputs.wikmd_tag }}
+
+      - name: Sleep
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '20s'
+
+      - name: Check running containers
+        run: docker ps -a
+
+      - name: Check docker logs
+        run: docker logs wikmd
+
+      # Check that Wikmd is up and running
+      - name: Assert wikmd status
+        run: curl -I localhost:5000 2>&1 | awk '/HTTP\// {print $2}' | grep -w "200\|301"
+
+  publish:
+    # Publish if official repo and push to 'main' or new tag
+    if: |
+      false &&
+      github.repository == 'Linbreux/wikmd' &&
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    runs-on: ubuntu-latest
+    needs: [build, test]
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Publish
+        uses: docker/build-push-action@v3
+        with:
+          file: docker/Dockerfile
+          push: true
+          tags: ${{ needs.build.outputs.wikmd_tag }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,22 @@
 FROM ghcr.io/linuxserver/baseimage-ubuntu:bionic
 
+COPY . /app/wikmd
+
 RUN \
   echo "**** install wikmd dependencies ****" && \
   apt-get update -y && \
   apt-get install -y python3-pip python3-dev pandoc git && \
-  echo "**** install wikmd ****" && \
-  WIKMD_RELEASE=$(curl -sX GET https://api.github.com/repos/Linbreux/wikmd/releases/latest \
-    | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||') && \
-  mkdir -p /app/wikmd && \
-  curl -o \
-    /tmp/wikmd.tar.gz -L \
-    https://github.com/Linbreux/wikmd/archive/master.tar.gz && \
-    #"https://github.com/Linbreux/wikmd/archive/refs/tags/v${WIKMD_RELEASE}.tar.gz" && \
-  tar xf /tmp/wikmd.tar.gz -C \
-    /app/wikmd --strip-components=1 && \
+  # echo "**** install wikmd ****" && \
+  # WIKMD_RELEASE=$(curl -sX GET https://api.github.com/repos/Linbreux/wikmd/releases/latest \
+  #   | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||') && \
+  # mkdir -p /app/wikmd && \
+  # curl -o \
+  #   /tmp/wikmd.tar.gz -L \
+  #   https://github.com/Linbreux/wikmd/archive/master.tar.gz && \
+  #   #"https://github.com/Linbreux/wikmd/archive/refs/tags/v${WIKMD_RELEASE}.tar.gz" && \
+  # tar xf /tmp/wikmd.tar.gz -C \
+  #   /app/wikmd --strip-components=1 && \
+  # cp -R . /app/wikmd && \
   echo "**** install pip requirements ****" && \
   cd /app/wikmd && \
   pip3 install -r requirements.txt && \
@@ -27,11 +30,10 @@ RUN \
     /var/tmp/* \
     /root/.cache
 
-COPY root/ /
+COPY docker/root/ /
 
 ENV LANG=C.UTF-8
 ENV HOME=/wiki
 
 # ports and volumes
 EXPOSE 5000
-

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -1,19 +1,21 @@
 FROM ghcr.io/linuxserver/baseimage-ubuntu:arm64v8-bionic
 
+COPY . /app/wikmd
+
 RUN \
   echo "**** install wikmd dependencies ****" && \
   apt-get update -y && \
   apt-get install -y python3-pip python3-dev pandoc git && \
-  echo "**** install wikmd ****" && \
-  WIKMD_RELEASE=$(curl -sX GET https://api.github.com/repos/Linbreux/wikmd/releases/latest \
-    | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||') && \
-  mkdir -p /app/wikmd && \
-  curl -o \
-    /tmp/wikmd.tar.gz -L \
-    https://github.com/Linbreux/wikmd/archive/master.tar.gz && \
-    #"https://github.com/Linbreux/wikmd/archive/refs/tags/v${WIKMD_RELEASE}.tar.gz" && \
-  tar xf /tmp/wikmd.tar.gz -C \
-    /app/wikmd --strip-components=1 && \
+  # echo "**** install wikmd ****" && \
+  # WIKMD_RELEASE=$(curl -sX GET https://api.github.com/repos/Linbreux/wikmd/releases/latest \
+  #   | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||') && \
+  # mkdir -p /app/wikmd && \
+  # curl -o \
+  #   /tmp/wikmd.tar.gz -L \
+  #   https://github.com/Linbreux/wikmd/archive/master.tar.gz && \
+  #   #"https://github.com/Linbreux/wikmd/archive/refs/tags/v${WIKMD_RELEASE}.tar.gz" && \
+  # tar xf /tmp/wikmd.tar.gz -C \
+  #   /app/wikmd --strip-components=1 && \
   echo "**** install pip requirements ****" && \
   cd /app/wikmd && \
   pip3 install -r requirements.txt && \
@@ -27,11 +29,10 @@ RUN \
     /var/tmp/* \
     /root/.cache
 
-COPY root/ /
+COPY docker/root/ /
 
 ENV LANG=C.UTF-8
 ENV HOME=/wiki
 
 # ports and volumes
 EXPOSE 5000
-

--- a/docker/Dockerfile.armhf
+++ b/docker/Dockerfile.armhf
@@ -1,19 +1,21 @@
 FROM ghcr.io/linuxserver/baseimage-ubuntu:arm32v7-bionic
 
+COPY . /app/wikmd
+
 RUN \
   echo "**** install wikmd dependencies ****" && \
   apt-get update -y && \
   apt-get install -y python3-pip python3-dev pandoc git && \
-  echo "**** install wikmd ****" && \
-  WIKMD_RELEASE=$(curl -sX GET https://api.github.com/repos/Linbreux/wikmd/releases/latest \
-    | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||') && \
-  mkdir -p /app/wikmd && \
-  curl -o \
-    /tmp/wikmd.tar.gz -L \
-    https://github.com/Linbreux/wikmd/archive/master.tar.gz && \
-    #"https://github.com/Linbreux/wikmd/archive/refs/tags/v${WIKMD_RELEASE}.tar.gz" && \
-  tar xf /tmp/wikmd.tar.gz -C \
-    /app/wikmd --strip-components=1 && \
+  # echo "**** install wikmd ****" && \
+  # WIKMD_RELEASE=$(curl -sX GET https://api.github.com/repos/Linbreux/wikmd/releases/latest \
+  #   | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||') && \
+  # mkdir -p /app/wikmd && \
+  # curl -o \
+  #   /tmp/wikmd.tar.gz -L \
+  #   https://github.com/Linbreux/wikmd/archive/master.tar.gz && \
+  #   #"https://github.com/Linbreux/wikmd/archive/refs/tags/v${WIKMD_RELEASE}.tar.gz" && \
+  # tar xf /tmp/wikmd.tar.gz -C \
+  #   /app/wikmd --strip-components=1 && \
   echo "**** install pip requirements ****" && \
   cd /app/wikmd && \
   pip3 install -r requirements.txt && \
@@ -27,11 +29,10 @@ RUN \
     /var/tmp/* \
     /root/.cache
 
-COPY root/ /
+COPY docker/root/ /
 
 ENV LANG=C.UTF-8
 ENV HOME=/wiki
 
 # ports and volumes
 EXPOSE 5000
-

--- a/docker/README.md
+++ b/docker/README.md
@@ -53,7 +53,7 @@ docker run -d \
   -p 5000:5000 \
   -v /path/to/wiki:/wiki \
   --restart unless-stopped \
-  wiki-md:latest
+  linbreux/wikmd:latest
 ```
 
 ## Parameters

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,7 +13,7 @@ Here are some example snippets to help you get started creating a container.
 Build the image,
 
 ```bash
-docker build -t linbreux/wikmd:latest .
+docker build -t linbreux/wikmd:latest -f docker/Dockerfile .
 ```
 
 ### docker-compose (recommended, [click here for more info](https://docs.linuxserver.io/general/docker-compose))
@@ -32,7 +32,6 @@ services:
       - HOMEPAGE=homepage.md #optional
       - HOMEPAGE_TITLE=homepage.md #optional
       - WIKMD_LOGGING=1 #optional
-      - WIKI_DIRECTORY=/wiki
     volumes:
       - /path/to/wiki:/wiki
     ports:
@@ -51,7 +50,6 @@ docker run -d \
   -e HOMEPAGE=homepage.md `#optional` \
   -e HOMEPAGE_TITLE=homepage.md `#optional` \
   -e WIKMD_LOGGING=1 `#optional` \
-  -e WIKI_DIRECTORY=/wiki \
   -p 5000:5000 \
   -v /path/to/wiki:/wiki \
   --restart unless-stopped \

--- a/docker/root/etc/cont-init.d/30-config
+++ b/docker/root/etc/cont-init.d/30-config
@@ -1,20 +1,27 @@
 #!/usr/bin/with-contenv bash
 
-touch /var/log/wikmd.log
-chown abc:abc /var/log/wikmd.log
-chown -R abc:abc /wiki
+# Create log file
+if [ ! -f "/var/log/wikmd.log" ]
+then
+  touch /var/log/wikmd.log
+  chown abc:abc /var/log/wikmd.log
+fi
 
-# if /wiki isn't mounted create it and populate it with the examples
+# if /wiki isn't mounted create it
 if [ ! -d "/wiki" ]
 then
   # create directories
   mkdir -p /wiki
+  chown abc:abc /wiki
+fi
 
+# If /wiki exists and is empty, populate it with the examples
+if [ -d "/wiki" ] && [ ! "$(ls -A /wiki)" ]
+then
   # copy examples
   cp /app/wikmd/wiki/*.md /wiki/.
 
   # permissions
-  chown -R abc:abc /wiki
-  chown -R abc:abc /app
+  chown -R abc:abc /wiki/*
 fi
 

--- a/docker/root/etc/services.d/wikmd/run
+++ b/docker/root/etc/services.d/wikmd/run
@@ -1,6 +1,5 @@
 #!/usr/bin/with-contenv bash
-export WIKI_DATA='/wiki'
+export WIKI_DIRECTORY='/wiki'
 export WIKMD_LOGGING_FILE='/var/log/wikmd.log'
 
 exec s6-setuidgid abc python3 /app/wikmd/wiki.py
-


### PR DESCRIPTION
### Summary

Fixing the Docker images and add a docker CI workflow.

### Details

- Changed context of the Dockerfiles so that they build from the local sources rather than from an artifact pulled from GitHub. This allows to build/publish images at different tags from the CI (e.g. `linbreux/wikmd:v1`, `linbreux/wikmd:1.2`, `linbreux/wikmd:main`, `linbreux/wikmd:pr-3` etc).
- Fixed the environment variable that changed `WIKI_DATA` -> `WIKI_DIRECTORY`
- The docker image does not change the permission of bind mounted volume anymore.
- Populate bind mounted volume with the examples if it is empty
- Update documentation
- Add a docker CI workflow
  - Build docker image
  - Test docker image
  - Publish docker image
 
The 'publish' part of the CI workflow is disabled for now. 

### Checks
~~- [ ] In case of new feature, add short overview in ```docs/<corresponding file>```~~
- [x] Tested changes
