### PR TITLE
fix docker image tagging

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,11 +31,9 @@ jobs:
           images: |
             linbreux/wikmd
           tags: |
-            type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern=v{{major}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=tag
+            type=edge,branch=$repo.default_branch
 
       - name: Check docker image tag
         run: |


### PR DESCRIPTION
### Summary

Fix the docker image tagging in CI.

### Details

Currently wikmd is not following the [semver](https://semver.org/) standard for git tags. This causes the [`metadata-action`](https://github.com/docker/metadata-action) to [silently fail](https://github.com/docker/metadata-action/issues/200) and an empty docker tag is generated. This empty tag is passed on all the way down to `docker run` which then fails.

With this change, the CI will create docker tags base on,
- pr number e.g. `linbreux/wikmd:pr-5`
- git tag e.g. `linbreux/wikmd:v1.6`
- `main` branch -> `linbreux/wikmd:edge`

### Checks
- [ ] In case of new feature, add short overview in ```docs/<corresponding file>``` 
- [ ] Tested changes
