### PR TITLE
add local mode

### DIFF
--- a/config.py
+++ b/config.py
@@ -24,6 +24,8 @@ HOMEPAGE_TITLE_DEFAULT = "homepage"
 PROTECT_EDIT_BY_PASSWORD = 0
 PASSWORD_IN_SHA_256 = "0E9C700FAB2D5B03B0581D080E74A2D7428758FC82BD423824C6C11D6A7F155E" #pw: wikmd
 
+# if False: Uses external CDNs to serve some files
+LOCAL_MODE = False
 
 class WikmdConfig:
     """
@@ -62,3 +64,5 @@ class WikmdConfig:
 
         self.protect_edit_by_password = os.getenv("PROTECT_EDIT_BY_PASSWORD") or yaml_config["protect_edit_by_password"] or PROTECT_EDIT_BY_PASSWORD
         self.password_in_sha_256 = os.getenv("PASSWORD_IN_SHA_256") or yaml_config["password_in_sha_256"] or PASSWORD_IN_SHA_256
+
+        self.local_mode = (os.getenv("LOCAL_MODE").lower() in ["true", "yes"]) or yaml_config["local_mode"] or LOCAL_MODE

--- a/config.py
+++ b/config.py
@@ -65,4 +65,4 @@ class WikmdConfig:
         self.protect_edit_by_password = os.getenv("PROTECT_EDIT_BY_PASSWORD") or yaml_config["protect_edit_by_password"] or PROTECT_EDIT_BY_PASSWORD
         self.password_in_sha_256 = os.getenv("PASSWORD_IN_SHA_256") or yaml_config["password_in_sha_256"] or PASSWORD_IN_SHA_256
 
-        self.local_mode = (os.getenv("LOCAL_MODE").lower() in ["true", "yes"]) or yaml_config["local_mode"] or LOCAL_MODE
+        self.local_mode = (os.getenv("LOCAL_MODE") in ["True", "true", "Yes", "yes"]) or yaml_config["local_mode"] or LOCAL_MODE

--- a/docs/environment variables.md
+++ b/docs/environment variables.md
@@ -58,6 +58,17 @@ export PASSWORD_IN_SHA_256 = <your password in sha 256>
 
 You can generate it via the console or just us a website (ex.[https://emn178.github.io/online-tools/sha256.html](https://emn178.github.io/online-tools/sha256.html)).
 
+## Local Mode
+
+If enabled wikmd will serve all `css` and `js` files itself.
+Otherwise the CDNs jsdelivr, cloudflare, polyfill and unpkg will be used.
+
+`Default = False`
+
+```
+export LOCAL_MODE=True
+```
+
 ## Change logging file
 
 In case you need to rename the log file you can use `WIKMD_LOGGING_FILE`.

--- a/docs/yaml-configuration.md
+++ b/docs/yaml-configuration.md
@@ -32,7 +32,9 @@ homepage: "homepage.md"
 homepage_title: "homepage"
 
 protect_edit_by_password: 0
-password_in_sha_256: "0E9C700FAB2D5B03B0581D080E74A2D7428758FC82BD423824C6C11D6A7F155E" #ps: wikmd 
+password_in_sha_256: "0E9C700FAB2D5B03B0581D080E74A2D7428758FC82BD423824C6C11D6A7F155E" #ps: wikmd
+
+local_mode: false
 ```
 
 Please, refer to [environment variables](environment%20variables.md) for further parameters explanation.

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ pandocfilters==1.4.3
 psutil==5.7.3
 pypandoc==1.5
 PyYAML==6.0
-requests==2.28.1
+requests==2.27.1
 smmap==3.0.4
 Werkzeug==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ PyYAML==6.0
 requests==2.27.1
 smmap==3.0.4
 Werkzeug==1.0.1
+idna==3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,6 @@ pandocfilters==1.4.3
 psutil==5.7.3
 pypandoc==1.5
 PyYAML==6.0
+requests==2.28.1
 smmap==3.0.4
 Werkzeug==1.0.1

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,14 +8,14 @@
 
     <!-- CSS -->
     <!-- Bootstrap -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet"
+    <link href="{{ system.web_deps["bootstrap.min.css"] }}" rel="stylesheet"
           integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
           crossorigin="anonymous">
     <!-- Highlight default/dark depending on the theme -->
     {% if system.darktheme == True %}
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/dark.min.css">
+        <link rel="stylesheet" href="{{ system.web_deps["dark.min.css"] }}">
     {% else %}
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/default.min.css">
+        <link rel="stylesheet" href="{{ system.web_deps["default.min.css"] }}">
     {% endif %}
     <!-- wikmd custom -->
     <link rel="stylesheet" type="text/css" href="/static/css/wiki.colors.css">
@@ -126,19 +126,19 @@
 
     <!-- Scripts -->
     <!-- Bootstrap Bundle with Popper -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+    <script src="{{ system.web_deps["bootstrap.bundle.min.js"] }}"
             integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
             crossorigin="anonymous"></script>
     <!-- JQuery -->
-    <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.slim.min.js"
+    <script src="{{ system.web_deps["jquery.slim.min.js"] }}"
             integrity="sha256-u7e5khyithlIdTpu22PHhENmPcRdFiHRjhAuHcs05RI="
             crossorigin="anonymous"></script>
     <!-- Polyfill -->
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script src="{{ system.web_deps["polyfill.min.js"] }}"></script>
     <!-- MatJax -->
-    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <script id="MathJax-script" async src="{{ system.web_deps["tex-mml-chtml.js"] }}"></script>
     <!-- Highlight -->
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/highlight.min.js"></script>
+    <script src="{{ system.web_deps["highlight.min.js"] }}"></script>
     <script>hljs.highlightAll();</script>
 </body>
 

--- a/templates/knowledge-graph.html
+++ b/templates/knowledge-graph.html
@@ -1,7 +1,7 @@
 {% extends 'base.html'%}
 
 {%block head%}
-    <script type="text/javascript" src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+    <script type="text/javascript" src="{{ system.web_deps["vis-network.min.js"] }}"></script>
 
     <style type="text/css">
         #mynetwork {

--- a/templates/new.html
+++ b/templates/new.html
@@ -3,7 +3,7 @@
 
 {%block head%}
     <link href="/static/css/filepond.css" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.52.2/codemirror.min.css" rel="stylesheet">
+    <link href="{{ system.web_deps["codemirror.min.css"] }}" rel="stylesheet">
     <link href="/static/css/codemirror.custom.css" rel="stylesheet">
 
     <!-- Add dark css if dark theme is toggled -->
@@ -32,8 +32,8 @@
         <button type="submit" class="btn btn-success mb-2">Save</button>
     </form>
 
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.52.2/codemirror.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.52.2/mode/markdown/markdown.min.js"></script>
+    <script type="text/javascript" src="{{ system.web_deps["codemirror.min.js"] }}"></script>
+    <script type="text/javascript" src="{{ system.web_deps["markdown.min.js"] }}"></script>
     <script type="text/javascript" src="/static/js/filepond.js"></script>
 
     <script>

--- a/web_dependencies.py
+++ b/web_dependencies.py
@@ -1,0 +1,89 @@
+from collections import namedtuple
+from os import path
+
+import requests
+
+WebDependency = namedtuple("WebDependency", ["local", "external"])
+WEB_DEPENDENCIES = {
+    "bootstrap.min.css": WebDependency(
+        local="/static/css/bootstrap.min.css",
+        external="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+    ),
+    "dark.min.css": WebDependency(
+        local="/static/css/dark.min.css",
+        external="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/dark.min.css"
+    ),
+    "default.min.css": WebDependency(
+        local="/static/css/default.min.css",
+        external="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/default.min.css"
+    ),
+    "bootstrap.bundle.min.js": WebDependency(
+        local="/static/js/bootstrap.bundle.min.js",
+        external="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+    ),
+    "jquery.slim.min.js": WebDependency(
+        local="/static/js/jquery.slim.min.js",
+        external="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.slim.min.js"
+    ),
+    "polyfill.min.js": WebDependency(
+        local="/static/js/polyfill.min.js",
+        external="https://polyfill.io/v3/polyfill.min.js?features=es6"
+    ),
+    "tex-mml-chtml.js": WebDependency(
+        local="/static/js/tex-mml-chtml.js",
+        external="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
+    ),
+    "highlight.min.js": WebDependency(
+        local="/static/js/highlight.min.js",
+        external="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/highlight.min.js"
+    ),
+    "codemirror.min.css": WebDependency(
+        local="/static/css/codemirror.min.css",
+        external="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.52.2/codemirror.min.css"
+    ),
+    "codemirror.min.js": WebDependency(
+        local="/static/js/codemirror.min.js",
+        external="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.52.2/codemirror.min.js"
+    ),
+    "markdown.min.js": WebDependency(
+        local="/static/js/markdown.min.js",
+        external="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.52.2/mode/markdown/markdown.min.js"
+    ),
+    "vis-network.min.js": WebDependency(
+        local="/static/js/vis-network.min.js",
+        external="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"
+    )
+}
+
+
+def get_web_deps(local_mode, logger):
+    """
+    Returns a dict with dependency_name as key and web_path as value.
+    If local_mode: a local copy of the dependency gets served
+    Else: a public CDNs gets used to serve those dependencies
+    """
+    if local_mode:
+        download_web_deps(logger)
+        return {dep: WEB_DEPENDENCIES[dep].local for dep in WEB_DEPENDENCIES}
+    else:
+        return {dep: WEB_DEPENDENCIES[dep].external for dep in WEB_DEPENDENCIES}
+
+
+def download_web_deps(logger):
+    """
+    Downloads the dependencies, if they don't already exist on disk
+    """
+    for dep_name in WEB_DEPENDENCIES:
+        dep = WEB_DEPENDENCIES[dep_name]
+        dep_file_path = path.join(path.dirname(__file__), dep.local[1:])  # Drop the first '/' so join works
+
+        # File is not present and has to be downloaded
+        if not path.exists(dep_file_path):
+            logger.info(f"Downloading dependency {dep.external}")
+            result = requests.get(dep.external)
+            if not result.ok:
+                raise Exception(f"Error while trying to GET {dep.external} Statuscode: {result.status_code}")
+
+            logger.info(f"Writing dependency >>> {dep_file_path}")
+            with open(dep_file_path, "wb") as file:
+                file.write(result.content)

--- a/wiki.py
+++ b/wiki.py
@@ -17,14 +17,10 @@ from hashlib import sha256
 
 from config import WikmdConfig
 from git_manager import WikiRepoManager
+from web_dependencies import get_web_deps
 
 
 ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif'}
-
-SYSTEM_SETTINGS = {
-    "darktheme": False,
-    "listsortMTime": False,
-}
 
 SESSIONS = []
 
@@ -43,6 +39,11 @@ logger.setLevel(logging.ERROR)
 
 wrm = WikiRepoManager(flask_app=app)
 
+SYSTEM_SETTINGS = {
+    "darktheme": False,
+    "listsortMTime": False,
+    "web_deps": get_web_deps(cfg.local_mode, app.logger)
+}
 
 def save(page_name):
     """

--- a/wikmd-config.yaml
+++ b/wikmd-config.yaml
@@ -19,3 +19,5 @@ homepage_title: "homepage"
 
 protect_edit_by_password: 0
 password_in_sha_256: "0E9C700FAB2D5B03B0581D080E74A2D7428758FC82BD423824C6C11D6A7F155E" #ps: wikmd 
+
+local_mode: false


### PR DESCRIPTION
### Summary
This pull request adds the local_mode. When in local_mode no external CDNs get used as requested in #50.

### Details
I added local_mode to `config.py`. If `cfg.local_mode` is `True` the web dependencies get downloaded, if they aren't already on disk. For this I added `requests` to the `requirements.txt`. The templates now use the `system.web_deps` dictionary to get the correct web path for the dependencies.

### Checks
- [x] In case of new feature, add short overview in ```docs/<corresponding file>``` 
- [x] Tested changes
