### PR TITLE
Add solutions for potentially obscure install issue

### DIFF
--- a/docs/installation/regular_install.md
+++ b/docs/installation/regular_install.md
@@ -9,7 +9,7 @@ nav_order: 1
 ! It's tested on windows and linux based systems.
 ! Runs on flask server
 
-Clone te repository
+Clone the repository
 ```
 git clone https://github.com/Linbreux/wikmd.git
 ```
@@ -47,6 +47,41 @@ Maybe you need to install pandoc on your system before this works.
 ```
 sudo apt-get update && sudo apt-get install pandoc
 ```
+You may experience an issue when running `pip install -r requirements.txt` where you receive the following error:
+```
+  psutil/_psutil_common.c:9:10: fatal error: Python.h: No such file or directory
+      9 | #include <Python.h>
+        |          ^~~~~~~~~~
+  compilation terminated.
+  error: command '/usr/lib64/ccache/gcc' failed with exit code 1
+  ----------------------------------------
+  ERROR: Failed building wheel for psutil
+ ```
+
+You can fix this by installing the python 3 dev package.
+
+Ubuntu, Debian:
+```
+sudo apt-get install python3-dev
+```
+Fedora:
+```
+sudo dnf install python3-devel
+```
+For other distros, you can search up `[distro] install python 3 dev`.
+
+You may experience an error when running `pip install -r requirements.txt` where it asks you to install `gcc python3-dev`. Example:
+```
+  unable to execute 'x86_64-linux-gnu-gcc': No such file or directory
+  C compiler or Python headers are not installed on this system. Try to run:
+  sudo apt-get install gcc python3-dev
+  error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
+  ----------------------------------------
+  ERROR: Failed building wheel for psutil
+```
+
+Simply install `gcc python3-dev`.
+
 
 ### Runing the wiki as a service
 


### PR DESCRIPTION
### Summary
Added a part in the install process on how to fix `Python.h is missing` error upon pip install by installing python3-dev.
Added a part in the install process on how to fix `gcc python3-dev is missing` error upon pip install.
Fixed one typo.

### Details
When i installed this, i encountered an issue when doing pip install requirements that would fail to build psutils, claiming Python.h was missing. took me a couple minutes to figure out how to fix it by installing python3-dev.

Decided to add back to the docs in hopes that it saves someone else some time.

I am unsure how common this issue is? i experienced this installing on both Fedora 36 and Ubuntu Server 20.04.

Also added a missing `h` letter. (te -> the)

### Checks
- [x] In case of new feature, add short overview in ```docs/<corresponding file>``` 
- [ ] Tested changes
