### PR TITLE
Fixes #58

### DIFF
--- a/knowledge_graph.py
+++ b/knowledge_graph.py
@@ -26,7 +26,7 @@ def find_links():
     # walk trough all files
     for root, subfolder, files in os.walk(cfg.wiki_directory):
         for item in files:
-            pagename = item.split(".")[0]
+            pagename, _ = os.path.splitext(item)
             path = os.path.join(root, item)
             value = {
                 "id": id,


### PR DESCRIPTION
### Summary
Fixes issue #58

### Details
Small change to use `os.path.splitext` to get the page name in the knowledge graph, allowing for page names to contain periods.

### Checks
- [x] Tested changes
