### PR TITLE
Added solution for missing python deps when running as service

### DIFF
--- a/docs/installation/regular_install.md
+++ b/docs/installation/regular_install.md
@@ -85,7 +85,9 @@ Simply install `gcc python3-dev`.
 
 ### Runing the wiki as a service
 
-You can run the wiki as a service. Doing this, will allow the wiki to boot at startup.
+You can run the wiki as a service. Doing this will allow the wiki to boot at startup.
+
+First, create the following file as `wiki.service` in `/etc/systemd/system`, and replace the placeholder entries.
 
 ```
 [Unit]
@@ -93,7 +95,7 @@ Description=Wikmd
 After=network.target
 
 [Service]
-User=brecht
+User=<user>
 WorkingDirectory=<path to the wiki>
 Environment=FLASK_APP=wiki.py
 ExecStart=<path to the wiki>/env/bin/python3 wiki.py
@@ -104,8 +106,6 @@ WantedBy=multi-user.target
 
 ```
 
-Put this file in ```/etc/systemd/system/``` as ```wiki.service```.
-
 Run the following commands to enable and start the serivce
 
 ```
@@ -113,6 +113,23 @@ systemctl daemon-reload
 systemctl enable wiki.service
 systemctl start wiki.service
 ```
+
+If the wiki opens, but does not display any text, run `systemctl status wiki.service`.
+
+You may see the following error:
+```
+ERROR in wiki: Conversion to HTML failed >>> Pandoc died with exitcode "83" during conversion: b'Error running filter pandoc-xnos:\nCould not find executable pandoc-xnos\n'
+```
+To fix, run the following commands:
+```
+sudo su
+cd ~
+umask 022
+pip install -r <path to the wiki>/requirements.txt
+```
+This will install the python packages system-wide, allowing the wiki service to access it.
+
+Run `systemctl restart wiki.service` and it should be working.
 
 
 ## Windows


### PR DESCRIPTION
### Summary
As i was installing this as a service on Ubuntu service 20.04.5 LTS, i came across three issues:
1. `/venv/` in service file was incorrectly written as `/env/`
2. user was predefined as `brecht`, which would cause the service to fail as user did not exist (may vary by machine)
3. service was unable to access installed python dependencies from the virtual environment and user space- and required installing from superuser

### Details
1. renamed `/env/` to `/venv/`
2. user entry was changed to `<user>` for the end user to change
3. added instructions on how to install requirements system-wide should the service not be able to access the virtual environment installed requirements

### Checks
- [x] In case of new feature, add short overview in ```docs/<corresponding file>``` 
- [x] Tested changes
