### PR TITLE
Create a fresh new cache each time wikmd is started/restarted

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -1,4 +1,5 @@
 import os
+from shutil import rmtree
 from typing import Optional
 
 import cachelib
@@ -8,8 +9,9 @@ class Cache:
     cache: cachelib.FileSystemCache
 
     def __init__(self, path: str):
-        if not os.path.exists(path):
-            os.makedirs(path)
+        if os.path.exists(path):
+            rmtree(path)  # delete an existing cache on start/restart
+        os.makedirs(path)
         self.cache = cachelib.FileSystemCache(path)
 
     def get(self, key: str) -> Optional[str]:


### PR DESCRIPTION
### Summary
Create a fresh new cache each time wikmd is started/restarted

### Details
This will fix an issue where creating a cache with a newer version of Python and then running wikmd again with an old version of Python would cause a `pickle` failure.

### Checks
- [x] Tested changes
