### PR TITLE
Fixes/changes for #65

### DIFF
--- a/git_manager.py
+++ b/git_manager.py
@@ -144,7 +144,7 @@ class WikiRepoManager:
         :param message: commit message.
         """
         try:
-            self.repo.git.add(spec)  # git add --all
+            self.repo.git.add("--all")  # git add --all
             self.repo.git.commit('-m', message)  # git commit -m
             self.flask_app.logger.info(f"New git commit >>> {message}")
         except Exception as e:


### PR DESCRIPTION
### Summary
A fix for abs path issues and documenting moving events.

### Details
Fixes:
* Rel paths causing abs paths to break when indexing documents
* git_manager bug added in the search feature that is a result of me not correctly removing the git_manager alterations when searchindex was moved from the wiki content directory

Adds:
* Ability for indexing moved documents. Without this change documents that are moved remain in the search index until a fresh index is created. This fixes that and correctly calls a delete() on the old path and index() on the new path.

### Checks
- [x] Tested changes
