### PR TITLE
fix the armhf and aarch64 Docker images

### DIFF
--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -5,7 +5,7 @@ COPY . /app/wikmd
 RUN \
   echo "**** install wikmd dependencies ****" && \
   apt-get update -y && \
-  apt-get install -y python3-pip python3-dev pandoc git && \
+  apt-get install -y python3-pip python3-dev pandoc git libxml2-dev libxslt1-dev && \
   # echo "**** install wikmd ****" && \
   # WIKMD_RELEASE=$(curl -sX GET https://api.github.com/repos/Linbreux/wikmd/releases/latest \
   #   | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||') && \

--- a/docker/Dockerfile.armhf
+++ b/docker/Dockerfile.armhf
@@ -5,7 +5,7 @@ COPY . /app/wikmd
 RUN \
   echo "**** install wikmd dependencies ****" && \
   apt-get update -y && \
-  apt-get install -y python3-pip python3-dev pandoc git && \
+  apt-get install -y python3-pip python3-dev pandoc git libxml2-dev libxslt1-dev && \
   # echo "**** install wikmd ****" && \
   # WIKMD_RELEASE=$(curl -sX GET https://api.github.com/repos/Linbreux/wikmd/releases/latest \
   #   | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||') && \


### PR DESCRIPTION
### Summary
The Arm docker images no longer built due to the lxml dependency.

### Details
I `apt install libxml2-dev libxslt1-dev` as required by the lxml package. I don't know why this isn't needed for x86_64.

### Checks
- [x] Tested changes
  - builds and works on armhf
  - builds on aarch64, haven't actually run it
