### PR TITLE
Remove the search term escaping to improve search functionality. 

### DIFF
--- a/wiki.py
+++ b/wiki.py
@@ -3,7 +3,6 @@ from shutil import ExecError
 import shutil
 import platform
 import time
-import re
 import logging
 import uuid
 from lxml.html.clean import clean_html
@@ -74,8 +73,6 @@ def search(search_term: str):
     """
     Function that searches for a term and shows the results.
     """
-    search_term = re.escape(search_term)
-
     app.logger.info(f"Searching >>> '{search_term}' ...")
     search = Search(cfg.search_dir)
     results, suggestions = search.search(search_term)


### PR DESCRIPTION
### Summary
Remove the search term escaping to improve search functionality. 

### Details
This will allow search to now correctly split terms, as well as allow using + to force AND in the search query.
i.e. `hi+hello` means `AND(Term(Hi), Term(Hello))`

By default a space means OR, i.e. `hi hello` means `OR(Term(hi), Term(hello))`

### Checks
- [x] Tested changes
