### PR TITLE
Add pagination to search results

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -10,48 +10,77 @@
         ul#list li {
             margin: 5px;
             padding-left: 15px;
-        {% if system.darktheme%}
+        {% if system.darktheme %}
             background: #222326;
-        {%endif%}
+        {% endif %}
             border-left-style: solid;
         }
 
         ul#list li:hover {
 
-        {% if system.darktheme%}
+        {% if system.darktheme %}
             background: #3f4448;
-        {%else%}
+        {% else %}
             background: #ECECEC;
-        {%endif%}
+        {% endif %}
         }
 
         ul#list li a {
             font-size: 1.2em;
 
-        {% if system.darktheme%}
+        {% if system.darktheme %}
             color: whitesmoke;
-        {%else%}
+        {% else %}
             color: #222326;
-        {%endif%}
+        {% endif %}
+        }
+
+        .pagination {
+           display: inline-block;
+        }
+
+        .pagination a {
+        {% if system.darktheme %}
+            color: whitesmoke;
+        {% else %}
+            color: #222326;
+        {% endif %}
+            float: left;
+            padding: 8px 16px;
+            text-decoration: none;
+        }
+
+        .pagination a.active {
+            background-color: #4CAF50;
+            color: whitesmoke;
         }
     </style>
 
 {% endblock %}
 
 {% block content %}
-    <h2>Found {{ results|length }} result(s) for '{{ search_term }}'</h2>
+    <h2>Found {{ num_results }} result(s) for '{{ search_term }}'</h2>
     <p>
         Did you mean?: 
         {% for term in suggestions %}
-        <a href="/?q={{ term }}">{{ term }}</a>
+            <a href="/?q={{ term }}">{{ term }}</a>
         {% if not loop.last %}, {% endif %}
     {% endfor %}
     <ul id="list">
         {% for res in results|sort(attribute="score", reverse=True) %}
             <li>
-                <p><a href="{{res.path}}/{{ res.title }}">{%if res.path != "."%}{{res.path}}/{%endif%}{{ res.title }}<a></p>
+                <p><a href="{{res.path}}/{{ res.title }}">{%if res.path != "."%}{{res.path}}/{%endif%}{{ res.title }}</a></p>
                 <p>{{ res.highlights|safe }}</p>
             </li>
         {% endfor %}
     </ul>
+    {% if num_pages > 1 %}
+        <ul class="pagination">
+        {% for page in range(1, num_pages + 1) %}
+            <li class="pagination">
+                <a href="/?q={{ search_term }}&page={{ page }}" {% if page == current_page %} class="active" {% endif %}>{{ page }}</a>
+            </li>
+        {% endfor %}
+        <ul>
+    {% endif %}
 {% endblock %}

--- a/wiki.py
+++ b/wiki.py
@@ -70,7 +70,7 @@ def save(page_name):
         app.logger.error(f"Error while saving '{page_name}' >>> {str(e)}")
 
 
-def search(search_term: str):
+def search(search_term: str, page: int):
     """
     Function that searches for a term and shows the results.
     """
@@ -78,10 +78,14 @@ def search(search_term: str):
 
     app.logger.info(f"Searching >>> '{search_term}' ...")
     search = Search(cfg.search_dir)
-    results, suggestions = search.search(search_term)
+    page = int(page)
+    results, num_results, num_pages, suggestions = search.search(search_term, page)
     return render_template(
         'search.html',
         search_term=search_term,
+        num_results=num_results,
+        num_pages=num_pages,
+        current_page=page,
         suggestions=suggestions,
         results=results,
         system=SYSTEM_SETTINGS,
@@ -151,7 +155,7 @@ def list_wiki(folderpath):
 @app.route('/<path:file_page>', methods=['GET'])
 def file_page(file_page):
     if request.args.get("q"):
-        return search(request.args.get("q"))
+        return search(request.args.get("q"), request.args.get("page", 1))
     else:
         html = ""
         mod = ""
@@ -193,7 +197,7 @@ def file_page(file_page):
 @app.route('/', methods=['GET'])
 def index():
     if request.args.get("q"):
-        return search(request.args.get("q"))
+        return search(request.args.get("q"), request.args.get("page", 1))
     else:
         html = ""
         app.logger.info("Showing HTML page >>> 'homepage'")


### PR DESCRIPTION
### Summary
Add pagination to search results

### Details
Adds pagination to search results rather than only display the top 10 results.

Here are a couple of screenshots of how it'll look in light mode and dark mode. _Please note that to easily test pagination here I simply copied the `Features.md` document 20 times and changed the filename, hence all the results are for `features`._
<img src=https://user-images.githubusercontent.com/109507/189531323-00af1608-05b0-4262-ba63-e06017893b2c.png width=512><img src=https://user-images.githubusercontent.com/109507/189531326-10b8e7f0-ff3e-4a63-b89c-bd2b5fe18acc.png width=512>

If there is only one page of search results, the pagination is not displayed
<img src=https://user-images.githubusercontent.com/109507/189532391-347f9a1c-b016-40dd-a96e-17ffe0b48a78.png width=512>


### Checks
- [x] Tested changes
