### PR TITLE
Change dark mode toggle to use a return path as a request argument rather than using the Referer header. Fixes #76

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -84,7 +84,7 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/toggle-darktheme">
+                        <a class="nav-link" href="/toggle-darktheme?return={{ url_for(request.endpoint, **request.view_args) }}">
                             <img src="/static/images/contrast-2-fill.svg" alt="toggle dark theme">
                         </a>
                     </li>

--- a/wiki.py
+++ b/wiki.py
@@ -357,7 +357,7 @@ def display_image(image_name):
 @app.route('/toggle-darktheme/', methods=['GET'])
 def toggle_darktheme():
     SYSTEM_SETTINGS['darktheme'] = not SYSTEM_SETTINGS['darktheme']
-    return redirect(request.referrer)  # redirect to the same page URL
+    return redirect(request.args.get("return", "/"))  # redirect to the same page URL
 
 
 @app.route('/toggle-sorting/', methods=['GET'])


### PR DESCRIPTION
### Summary
Change dark mode toggle to use a return path as a request argument rather than using the Referer header.
Fixes #76

### Details
Really simple change, it'll add a return path to the `toggle-darktheme` route as a query string, if one isn't provided it will default to directing the user to `/` after toggling.

### Checks
- [x] Tested changes
