### PR TITLE
Godlike editing speed: redirecting to /add_new if page does not exist

### DIFF
--- a/wiki.py
+++ b/wiki.py
@@ -109,6 +109,8 @@ def fetch_page_name() -> str:
 
 def new_page_name() -> str:
     page_name = request.args.get('path')
+    if page_name == None:
+        page_name = ""
     return page_name
 
 
@@ -230,7 +232,7 @@ def file_page(file_page):
                                    system=SYSTEM_SETTINGS)
         except FileNotFoundError as e:
             app.logger.info(e)
-            return redirect("/add_new")
+            return redirect("/add_new?page=" + file_page)
 
 
 @app.route('/', methods=['GET'])

--- a/wiki.py
+++ b/wiki.py
@@ -107,6 +107,10 @@ def fetch_page_name() -> str:
         page_name = f"{page_name[:-4]}{uuid.uuid4().hex}"
     return page_name
 
+def new_page_name() -> str:
+    page_name = request.args['path']
+    return page_name
+
 
 @app.route('/list/', methods=['GET'])
 def list_full_wiki():
@@ -267,8 +271,9 @@ def add_new():
 
         return redirect(url_for("file_page", file_page=page_name))
     else:
+        page_name = new_page_name()
         return render_template('new.html', upload_path=cfg.images_route,
-                               image_allowed_mime=cfg.image_allowed_mime, system=SYSTEM_SETTINGS)
+                               image_allowed_mime=cfg.image_allowed_mime, title=page_name, system=SYSTEM_SETTINGS)
 
 
 @app.route('/edit/homepage', methods=['POST', 'GET'])
@@ -415,6 +420,10 @@ def toggle_sort():
 def favicon():
     return send_from_directory(os.path.join(app.root_path, 'static'),
                                'favicon.ico', mimetype='image/vnd.microsoft.icon')
+
+@app.errorhandler(404)
+def not_found(e):
+    return redirect("/add_new")
 
 def setup_search():
     search = Search(cfg.search_dir, create=True)

--- a/wiki.py
+++ b/wiki.py
@@ -107,14 +107,6 @@ def fetch_page_name() -> str:
         page_name = f"{page_name[:-4]}{uuid.uuid4().hex}"
     return page_name
 
-def new_page_name() -> str:
-    page_name = request.args.get('path')
-    app.logger.info("Page name: " + page_name)
-    if page_name == None:
-        page_name = ""
-    return page_name
-
-
 @app.route('/list/', methods=['GET'])
 def list_full_wiki():
     return list_wiki("")
@@ -278,10 +270,11 @@ def add_new():
 
         return redirect(url_for("file_page", file_page=page_name))
     else:
-        page_name = new_page_name()
+        page_name = request.args.get("page")
+        if page_name == None:
+            page_name = ""
         return render_template('new.html', upload_path=cfg.images_route,
                                image_allowed_mime=cfg.image_allowed_mime, title=page_name, system=SYSTEM_SETTINGS)
-
 
 @app.route('/edit/homepage', methods=['POST', 'GET'])
 def edit_homepage():
@@ -427,10 +420,6 @@ def toggle_sort():
 def favicon():
     return send_from_directory(os.path.join(app.root_path, 'static'),
                                'favicon.ico', mimetype='image/vnd.microsoft.icon')
-
-@app.errorhandler(404)
-def not_found(e):
-    return redirect("/add_new")
 
 def setup_search():
     search = Search(cfg.search_dir, create=True)

--- a/wiki.py
+++ b/wiki.py
@@ -108,7 +108,7 @@ def fetch_page_name() -> str:
     return page_name
 
 def new_page_name() -> str:
-    page_name = request.args['path']
+    page_name = request.args.get('path')
     return page_name
 
 

--- a/wiki.py
+++ b/wiki.py
@@ -109,6 +109,7 @@ def fetch_page_name() -> str:
 
 def new_page_name() -> str:
     page_name = request.args.get('path')
+    app.logger.info("Page name: " + page_name)
     if page_name == None:
         page_name = ""
     return page_name


### PR DESCRIPTION
### Summary

Instead of showing a traceback error page, we can do something more useful: prompt a user to create a new page if it does not exist! Bonus: by using `?page=` url parameter we can specify which page we are going to edit. See the example below.

![editing](https://user-images.githubusercontent.com/674257/218706812-b01b95cd-d603-40b8-99d8-99cecf36b126.gif)

### Details

Before displaying a page, wikmd checks mtime of a file. If a file does not exist, it will throw a FileNotFound error. We can catch this error and do a redirect instead. More to that, we can pass a page name as an argument to the `/add_new` route and therefore put the path to a page right into a template.

### Checks
- [ ] In case of new feature, add short overview in ```docs/<corresponding file>``` 
- [x] Tested changes
