### PR TITLE
Switched to GFM Markdown flavour to allow rendering checkboxes

### DIFF
--- a/wiki.py
+++ b/wiki.py
@@ -5,7 +5,7 @@ import platform
 import time
 import logging
 import uuid
-from lxml.html.clean import clean_html
+from lxml.html.clean import Cleaner
 import pypandoc
 import knowledge_graph
 import secrets
@@ -170,6 +170,7 @@ def file_page(file_page):
         html = ""
         mod = ""
         folder = ""
+        cleaner = Cleaner(forms=False)
 
         if "favicon" in file_page:  # if the GET request is not for the favicon
             return
@@ -202,7 +203,7 @@ def file_page(file_page):
                 html = pypandoc.convert_file(md_file_path, "html5",
                                     format='gfm', extra_args=["--mathjax"], filters=['pandoc-xnos'])
                 
-                html = clean_html(html)
+                html = cleaner.clean_html(html)
 
                 for plugin in plugins:
                     if ("process_before_cache_html" in dir(plugin)):
@@ -234,6 +235,7 @@ def index():
         return search(request.args.get("q"), request.args.get("page", 1))
     else:
         html = ""
+        cleaner = Cleaner(forms=False)
         app.logger.info("Showing HTML page >>> 'homepage'")
 
         md_file_path = os.path.join(cfg.wiki_directory, cfg.homepage)
@@ -249,7 +251,7 @@ def index():
             html = pypandoc.convert_file(
                 md_file_path, "html5", format='gfm', extra_args=["--mathjax"],
                 filters=['pandoc-xnos'])
-            html = clean_html(html)
+            html = cleaner.clean_html(html)
             cache.set(md_file_path, html)
 
         except Exception as e:

--- a/wiki.py
+++ b/wiki.py
@@ -200,7 +200,7 @@ def file_page(file_page):
                 app.logger.info(f"Converting to HTML with pandoc >>> '{md_file_path}' ...")
 
                 html = pypandoc.convert_file(md_file_path, "html5",
-                                    format='md', extra_args=["--mathjax"], filters=['pandoc-xnos'])
+                                    format='gfm', extra_args=["--mathjax"], filters=['pandoc-xnos'])
                 
                 html = clean_html(html)
 
@@ -247,7 +247,7 @@ def index():
         try:
             app.logger.info("Converting to HTML with pandoc >>> 'homepage' ...")
             html = pypandoc.convert_file(
-                md_file_path, "html5", format='md', extra_args=["--mathjax"],
+                md_file_path, "html5", format='gfm', extra_args=["--mathjax"],
                 filters=['pandoc-xnos'])
             html = clean_html(html)
             cache.set(md_file_path, html)


### PR DESCRIPTION
### Summary

In GFM one can use `[ ]` and `[x]` in lists to draw checkboxes. That helps to track progress in some documents (not intending to use Wikmd as a task tracker, but that may be useful to display status of things, and it's much quicker to type than ~~strikethrough~~)

![image](https://user-images.githubusercontent.com/674257/222504611-bab90912-b3e8-4b71-a2da-adb3b8f6a974.png)

### Details

Adding this feature involved two things:

+ Changing markup to `gfm` in Pandoc
+ Excluding form elements from html Cleaner

Please feel free to reject the PR if any of my changes violate the design.

### Checks
- [ ] In case of new feature, add short overview in ```docs/<corresponding file>``` 
- [x] Tested changes
