### PR TITLE
fix: move regexp into the start of the pattern

### DIFF
--- a/plugins/alerts/alerts.py
+++ b/plugins/alerts/alerts.py
@@ -39,10 +39,10 @@ class Plugin:
 
 
         result = file
-        result = re.sub(r"(\<p)()(\>)\[\[(?i)warning\]\](.*)\<\/p\>", r"<div class='alert alert-warning d-flex'\3"+warning_icon+r" <a>\4</a></div>", result)
-        result = re.sub(r"(\<p)()(\>)\[\[(?i)info\]\](.*)\<\/p\>", r"<div class='alert alert-info d-flex'\3"+info_icon+r" <a>\4</a></div>", result)
-        result = re.sub(r"(\<p)()(\>)\[\[(?i)danger\]\](.*)\<\/p\>", r"<div class='alert alert-danger d-flex'\3"+danger_icon+r" <a>\4</a></div>", result)
-        result = re.sub(r"(\<p)()(\>)\[\[(?i)success\]\](.*)\<\/p\>", r"<div class='alert alert-success d-flex'\3"+success_icon+r" <a>\4</a></div>", result)
+        result = re.sub(r"(?i)(\<p)()(\>)\[\[warning\]\](.*)\<\/p\>", r"<div class='alert alert-warning d-flex'\3"+warning_icon+r" <a>\4</a></div>", result)
+        result = re.sub(r"(?i)(\<p)()(\>)\[\[info\]\](.*)\<\/p\>", r"<div class='alert alert-info d-flex'\3"+info_icon+r" <a>\4</a></div>", result)
+        result = re.sub(r"(?i)(\<p)()(\>)\[\[danger\]\](.*)\<\/p\>", r"<div class='alert alert-danger d-flex'\3"+danger_icon+r" <a>\4</a></div>", result)
+        result = re.sub(r"(?i)(\<p)()(\>)\[\[success\]\](.*)\<\/p\>", r"<div class='alert alert-success d-flex'\3"+success_icon+r" <a>\4</a></div>", result)
 
         return result
 


### PR DESCRIPTION
### Summary
This is required on newer version of python and shouldn't change the regexp outcome.
