### PR TITLE
fix:do not attempt to clean html if it's empty

### DIFF
--- a/wiki.py
+++ b/wiki.py
@@ -151,7 +151,8 @@ def get_html(file_page):
     html = pypandoc.convert_file(md_file_path, "html5",
                                     format='md', extra_args=["--mathjax"], filters=['pandoc-xnos'])
 
-    html = clean_html(html)
+    if html.strip():
+        html = clean_html(html)
 
     for plugin in plugins:
         if "process_before_cache_html" in dir(plugin):


### PR DESCRIPTION
### Summary
Fixes the `lxml.etree.ParserError` error you get when you try to create an empty page or edit an page by deleting all text you will get an error