### PR TITLE
fix: use uri for search

### DIFF
--- a/src/wikmd/templates/base.html
+++ b/src/wikmd/templates/base.html
@@ -44,7 +44,7 @@
             </button>
 
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                <form class="d-flex my-sm-4 my-lg-0 ms-lg-4" method="GET" action="/">
+                <form class="d-flex my-sm-4 my-lg-0 ms-lg-4" method="GET" action="{{ url_for('search_route') }}">
                     <input class="form-control me-2" type="search" placeholder="Search something..." aria-label="Search" name="q">
                     <button class="btn btn-primary me-2" type="submit">
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-search">

--- a/src/wikmd/templates/search.html
+++ b/src/wikmd/templates/search.html
@@ -63,7 +63,7 @@
     <p>
         Did you mean?: 
         {% for term in suggestions %}
-            <a href="/?q={{ term }}">{{ term }}</a>
+            <a href="{{ url_for('search_route') }}?q={{ term }}">{{ term }}</a>
         {% if not loop.last %}, {% endif %}
     {% endfor %}
     <ul id="list">
@@ -78,7 +78,7 @@
         <ul class="pagination">
         {% for page in range(1, num_pages + 1) %}
             <li class="pagination">
-                <a href="/?q={{ search_term }}&page={{ page }}" {% if page == current_page %} class="active" {% endif %}>{{ page }}</a>
+                <a href="{{ url_for('search_route') }}?q={{ search_term }}&page={{ page }}" {% if page == current_page %} class="active" {% endif %}>{{ page }}</a>
             </li>
         {% endfor %}
         <ul>

--- a/src/wikmd/wiki.py
+++ b/src/wikmd/wiki.py
@@ -257,63 +257,59 @@ def list_wiki(folderpath):
     return render_template('list_files.html', list=files_list, folder=folderpath, system=SYSTEM_SETTINGS)
 
 
-@app.route('/<path:file_page>', methods=['GET'])
-def file_page(file_page):
+@app.route('/search', methods=['GET'])
+def search_route():
     if request.args.get("q"):
         return search(request.args.get("q"), request.args.get("page", 1))
-    else:
+    flash("You didn't enter anything to search for")
+    return redirect("/")
 
-        git_sync_thread = Thread(target=wrm.git_pull, args=())
-        git_sync_thread.start()
 
-        html = ""
-        mod = ""
-        folder = ""
+@app.route('/<path:file_page>', methods=['GET'])
+def file_page(file_page):
+    git_sync_thread = Thread(target=wrm.git_pull, args=())
+    git_sync_thread.start()
 
-        if "favicon" in file_page:  # if the GET request is not for the favicon
-            return
+    if "favicon" in file_page:  # if the GET request is not for the favicon
+        return
 
-        try:
-            html_content, mod = get_html(file_page)
+    try:
+        html_content, mod = get_html(file_page)
 
-            return render_template(
-                'content.html', title=file_page, folder=folder, info=html_content, modif=mod,
-                system=SYSTEM_SETTINGS
-        )
-        except FileNotFoundError as e:
-            app.logger.info(e)
-            return redirect("/add_new?page=" + file_page)
+        return render_template(
+            'content.html', title=file_page, folder="", info=html_content, modif=mod,
+            system=SYSTEM_SETTINGS
+    )
+    except FileNotFoundError as e:
+        app.logger.info(e)
+        return redirect("/add_new?page=" + file_page)
 
 
 @app.route('/', methods=['GET'])
 def index():
-    if request.args.get("q"):
-        return search(request.args.get("q"), request.args.get("page", 1))
-    else:
-        
-        html = ""
-        app.logger.info("Showing HTML page >>> 'homepage'")
+    html = ""
+    app.logger.info("Showing HTML page >>> 'homepage'")
 
-        md_file_path = os.path.join(cfg.wiki_directory, cfg.homepage)
-        cached_entry = cache.get(md_file_path)
-        if cached_entry:
-            app.logger.info("Showing HTML page from cache >>> 'homepage'")
-            return render_template(
-                'index.html', homepage=cached_entry, system=SYSTEM_SETTINGS
-            )
+    md_file_path = os.path.join(cfg.wiki_directory, cfg.homepage)
+    cached_entry = cache.get(md_file_path)
+    if cached_entry:
+        app.logger.info("Showing HTML page from cache >>> 'homepage'")
+        return render_template(
+            'index.html', homepage=cached_entry, system=SYSTEM_SETTINGS
+        )
 
-        try:
-            app.logger.info("Converting to HTML with pandoc >>> 'homepage' ...")
-            html = pypandoc.convert_file(
-                md_file_path, "html5", format='md', extra_args=["--mathjax"],
-                filters=['pandoc-xnos'])
-            html = clean_html(html)
-            cache.set(md_file_path, html)
+    try:
+        app.logger.info("Converting to HTML with pandoc >>> 'homepage' ...")
+        html = pypandoc.convert_file(
+            md_file_path, "html5", format='md', extra_args=["--mathjax"],
+            filters=['pandoc-xnos'])
+        html = clean_html(html)
+        cache.set(md_file_path, html)
 
-        except Exception as e:
-            app.logger.error(f"Conversion to HTML failed >>> {str(e)}")
+    except Exception as e:
+        app.logger.error(f"Conversion to HTML failed >>> {str(e)}")
 
-        return render_template('index.html', homepage=html, system=SYSTEM_SETTINGS)
+    return render_template('index.html', homepage=html, system=SYSTEM_SETTINGS)
 
 
 @app.route('/add_new', methods=['POST', 'GET'])

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -67,7 +67,7 @@ def test_create_file_in_folder(wiki_file, test_file_content):
 def test_search():
     """Search functionality returns result."""
     wiki.setup_search()
-    rv = app.test_client().get("/?q=Features")
+    rv = app.test_client().get("/search?q=Features")
     assert rv.status_code == 200
     assert b"Found" in rv.data
     assert b"result(s)" in rv.data


### PR DESCRIPTION
### Summary
It's conventional to use a uri for searching

### Details
It also makes the code cleaner as it do not have to guard against a search everywhere.
_Technically_ a breaking change as someone _could_ have saved a search as a bookmark, or done other things that assumes the search location. However, I don't think that's worth taking into consideration.
