### PR TITLE
Adding ruff to dependencies as well as removing some rules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[dev]
+        pip install .[test]
     - name: Test with pytest
       run: |
         python -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,11 @@ dependencies=[
 [project.optional-dependencies]
 dev = [
     "pytest",
+    "ruff",
+    "ruff-lsp",
+]
+test = [
+    "pytest",
 ]
 
 [project.scripts]
@@ -63,6 +68,23 @@ src = ["", "tests"]
 select = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
+"*" = [
+    # ANN001: Missing type annotation for public function
+    "ANN101",
+
+    # ANN204: Missing return type annotation for __init__
+    "ANN204",
+
+    # D100: Missing docstring in public module
+    "D100",
+
+    # D107: Missing docstring in __init__
+    "D107",
+
+    # ANN001: Missing type annotation for public function
+    "ANN101",
+]
+
 "tests/*" = [
     # S101: Check for assert
     "S101",
@@ -72,9 +94,6 @@ select = ["ALL"]
 
     # ANN201: Missing return type annotation for public function
     "ANN201",
-
-    # D100: Missing docstring in public module
-    "D100",
 
     # D103: Missing docstring in public function
     "D103",


### PR DESCRIPTION
### Summary
Added ruff as a dev dependency

### Details
Removed some rules I personally don't care about, however you as the project manager should decide on rules you like and don't like. If you enable Ruff right now the project will light up like a Christmas tree. You can then easy see which rules you don't like and then add them to the list in the project.

