### PR TITLE
Missing drawings from git

### DIFF
--- a/src/wikmd/config.py
+++ b/src/wikmd/config.py
@@ -21,6 +21,7 @@ WIKI_DIRECTORY_DEFAULT = "wiki"
 HOMEPAGE_DEFAULT = "homepage.md"
 HOMEPAGE_TITLE_DEFAULT = "homepage"
 IMAGES_ROUTE_DEFAULT = "img"
+DRAWINGS_ROUTE_DEFAULT = ".drawings"
 
 HIDE_FOLDER_IN_WIKI = []
 
@@ -89,6 +90,7 @@ class WikmdConfig:
         self.homepage = os.getenv("HOMEPAGE") or yaml_config.get("homepage", HOMEPAGE_DEFAULT)
         self.homepage_title = os.getenv("HOMEPAGE_TITLE") or yaml_config.get("homepage_title", HOMEPAGE_TITLE_DEFAULT)
         self.images_route = os.getenv("IMAGES_ROUTE") or yaml_config.get("images_route", IMAGES_ROUTE_DEFAULT)
+        self.drawings_route = DRAWINGS_ROUTE_DEFAULT
 
         self.hide_folder_in_wiki = os.getenv("HIDE_FOLDER_IN_WIKI") or yaml_config.get("hide_folder_in_wiki", HIDE_FOLDER_IN_WIKI)
 

--- a/src/wikmd/plugins/draw/draw.py
+++ b/src/wikmd/plugins/draw/draw.py
@@ -18,7 +18,8 @@ class Plugin:
         self.config = config
         self.this_location = os.path.dirname(__file__)
         self.web_dep = web_dep
-        self.drawings_folder = os.path.join(self.config.wiki_directory, "drawings")
+        self.drawings_folder = os.path.join(self.config.wiki_directory, config.drawings_route)
+
         if not os.path.exists(self.drawings_folder):
             os.mkdir(self.drawings_folder)
 

--- a/src/wikmd/plugins/draw/draw.py
+++ b/src/wikmd/plugins/draw/draw.py
@@ -18,6 +18,9 @@ class Plugin:
         self.config = config
         self.this_location = os.path.dirname(__file__)
         self.web_dep = web_dep
+        self.drawings_folder = os.path.join(self.config.wiki_directory, "drawings")
+        if not os.path.exists(self.drawings_folder):
+            os.mkdir(self.drawings_folder)
 
     def get_plugin_name(self) -> str:
         """
@@ -47,7 +50,7 @@ class Plugin:
         self.flask_app.logger.info(f"Plug/{self.name} - changing drawing {id}")
 
         # look for folder
-        location = os.path.join(os.path.dirname(__file__), "drawings", id)
+        location = os.path.join(self.drawings_folder, id)
         if os.path.exists(location):
             file = open(location, "w")
             file.write(image)
@@ -60,7 +63,7 @@ class Plugin:
         look for a drawId in the wiki/draw folder and return the file as a string
         """
         try:
-            file = open(os.path.join(self.this_location, "drawings", drawid), "r")
+            file = open(os.path.join(self.drawings_folder, drawid), "r")
             return file.read()
         except Exception:
             print("Did not find the file")
@@ -70,7 +73,7 @@ class Plugin:
         """
         Copy the default drawing to a new one with this filename
         """
-        path_to_file = os.path.join(self.this_location, "drawings", filename)
+        path_to_file = os.path.join(self.drawings_folder, filename)
         shutil.copyfile(os.path.join(self.this_location, "default_draw"), path_to_file)
         s = open(path_to_file,"r")
         result = re.sub("id=\"\"","id=\"" + filename + "\"",s.read())

--- a/src/wikmd/plugins/draw/draw.py
+++ b/src/wikmd/plugins/draw/draw.py
@@ -23,6 +23,13 @@ class Plugin:
         if not os.path.exists(self.drawings_folder):
             os.mkdir(self.drawings_folder)
 
+            # allow backward compatibility and move all the contents in the plugins
+            # drawing folder to the wiki drawings folder
+            for item in os.listdir(os.path.join(self.this_location, "drawings")):
+                print(f"copy {item} to {self.drawings_folder}")
+                shutil.copy2(os.path.join(self.this_location, "drawings",item), os.path.join(self.drawings_folder, item))
+
+
     def get_plugin_name(self) -> str:
         """
         returns the name of the plugin

--- a/src/wikmd/plugins/draw/draw.py
+++ b/src/wikmd/plugins/draw/draw.py
@@ -20,6 +20,11 @@ class Plugin:
         self.web_dep = web_dep
         self.drawings_folder = os.path.join(self.config.wiki_directory, config.drawings_route)
 
+    def post_setup(self) -> bool:
+        """
+        configure the drawings folder
+        returns True if folder did not exist and created it
+        """
         if not os.path.exists(self.drawings_folder):
             os.mkdir(self.drawings_folder)
 
@@ -28,7 +33,9 @@ class Plugin:
             for item in os.listdir(os.path.join(self.this_location, "drawings")):
                 print(f"copy {item} to {self.drawings_folder}")
                 shutil.copy2(os.path.join(self.this_location, "drawings",item), os.path.join(self.drawings_folder, item))
+            return True
 
+        return False
 
     def get_plugin_name(self) -> str:
         """

--- a/src/wikmd/plugins/draw/draw.py
+++ b/src/wikmd/plugins/draw/draw.py
@@ -18,13 +18,14 @@ class Plugin:
         self.config = config
         self.this_location = os.path.dirname(__file__)
         self.web_dep = web_dep
-        self.drawings_folder = os.path.join(self.config.wiki_directory, config.drawings_route)
+        self.drawings_folder = None
 
     def post_setup(self) -> bool:
         """
         configure the drawings folder
         returns True if folder did not exist and created it
         """
+        self.drawings_folder = os.path.join(self.config.wiki_directory, self.config.drawings_route)
         if not os.path.exists(self.drawings_folder):
             os.mkdir(self.drawings_folder)
 

--- a/src/wikmd/wiki.py
+++ b/src/wikmd/wiki.py
@@ -39,7 +39,7 @@ cfg = WikmdConfig()
 
 UPLOAD_FOLDER_PATH = pathify(cfg.wiki_directory, cfg.images_route)
 GIT_FOLDER_PATH = pathify(cfg.wiki_directory, '.git')
-DRAWING_FOLDER_PATH = pathify(cfg.wiki_directory, 'drawings')
+DRAWING_FOLDER_PATH = pathify(cfg.wiki_directory, cfg.drawings_route)
 HIDDEN_FOLDER_PATH_LIST = [pathify(cfg.wiki_directory, hidden_folder) for hidden_folder in cfg.hide_folder_in_wiki]
 HOMEPAGE_PATH = pathify(cfg.wiki_directory, cfg.homepage)
 HIDDEN_PATHS = tuple([UPLOAD_FOLDER_PATH, GIT_FOLDER_PATH, DRAWING_FOLDER_PATH, HOMEPAGE_PATH] + HIDDEN_FOLDER_PATH_LIST)

--- a/src/wikmd/wiki.py
+++ b/src/wikmd/wiki.py
@@ -541,6 +541,11 @@ def setup_wiki_template() -> bool:
         app.logger.info("Wiki directory is empty, copy template")
         shutil.copytree(root / "wiki_template", cfg.wiki_directory, dirs_exist_ok=True)
         return True
+
+    for plugin in plugins:
+        if "post_setup" in dir(plugin):
+            plugin.post_setup()
+
     return False
 
 

--- a/src/wikmd/wiki.py
+++ b/src/wikmd/wiki.py
@@ -39,9 +39,10 @@ cfg = WikmdConfig()
 
 UPLOAD_FOLDER_PATH = pathify(cfg.wiki_directory, cfg.images_route)
 GIT_FOLDER_PATH = pathify(cfg.wiki_directory, '.git')
+DRAWING_FOLDER_PATH = pathify(cfg.wiki_directory, 'drawings')
 HIDDEN_FOLDER_PATH_LIST = [pathify(cfg.wiki_directory, hidden_folder) for hidden_folder in cfg.hide_folder_in_wiki]
 HOMEPAGE_PATH = pathify(cfg.wiki_directory, cfg.homepage)
-HIDDEN_PATHS = tuple([UPLOAD_FOLDER_PATH, GIT_FOLDER_PATH, HOMEPAGE_PATH] + HIDDEN_FOLDER_PATH_LIST)
+HIDDEN_PATHS = tuple([UPLOAD_FOLDER_PATH, GIT_FOLDER_PATH, DRAWING_FOLDER_PATH, HOMEPAGE_PATH] + HIDDEN_FOLDER_PATH_LIST)
 
 _project_folder = Path(__file__).parent
 app = Flask(__name__,

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -87,6 +87,7 @@ def test_search():
 
 def test_add_new_file(wiki_path):
     """App can create files."""
+    wiki.setup_wiki_template()
     rv = app.test_client().get("/add_new")
     assert rv.status_code == 200
     assert b"content" in rv.data


### PR DESCRIPTION
### Summary
Add drawings to wiki folder. This allows them to be in git.

See issue #150


### Checks
- [x] In case of new feature, add short overview in ```docs/<corresponding file>``` 
- [x] Tested changes
