### PR TITLE
Get polyfill.js from cloudflare

### DIFF
--- a/src/wikmd/web_dependencies.py
+++ b/src/wikmd/web_dependencies.py
@@ -31,7 +31,7 @@ WEB_DEPENDENCIES = {
     ),
     "polyfill.min.js": WebDependency(
         local="/static/js/polyfill.min.js",
-        external="https://polyfill.io/v3/polyfill.min.js?features=es6"
+        external="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"
     ),
     "tex-mml-chtml.js": WebDependency(
         local="/static/js/tex-mml-chtml.js",


### PR DESCRIPTION
### Summary

Polyfill.io doesn't have the best reputation these days. I've changed the source of the script to cloudflare.

- https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk
- https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet

### Tests

The only test I've done is starting a container with LOCAL_MODE true and false. Can do additional tests but I'll need some pointers :)

### Checks

- [X] Tested changes
