### PR TITLE
Download bootstrap-icons fonts in local_mode

### DIFF
--- a/src/wikmd/web_dependencies.py
+++ b/src/wikmd/web_dependencies.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from os import path
+from os import path, makedirs
 
 import requests
 
@@ -24,6 +24,14 @@ WEB_DEPENDENCIES = {
     "bootstrap-icons.css": WebDependency(
         local="/static/css/bootstrap-icons.css",
         external="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css"
+    ),
+    "bootstrap-icons.woff": WebDependency(
+        local="/static/css/fonts/bootstrap-icons.woff",
+        external="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/fonts/bootstrap-icons.woff"
+    ),
+    "bootstrap-icons.woff2": WebDependency(
+        local="/static/css/fonts/bootstrap-icons.woff2",
+        external="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/fonts/bootstrap-icons.woff2"
     ),
     "jquery.slim.min.js": WebDependency(
         local="/static/js/jquery.slim.min.js",
@@ -116,6 +124,12 @@ def download_web_deps(logger):
     for dep_name in WEB_DEPENDENCIES:
         dep = WEB_DEPENDENCIES[dep_name]
         dep_file_path = path.join(path.dirname(__file__), dep.local[1:])  # Drop the first '/' so join works
+        dep_folder_path = path.dirname(dep_file_path)
+
+        # Dependency parent folder is not present and has to be created
+        if not path.exists(dep_folder_path):
+            logger.info(f"Creating dependency folder {dep_folder_path}")
+            makedirs(dep_folder_path)
 
         # File is not present and has to be downloaded
         if not path.exists(dep_file_path):


### PR DESCRIPTION
### Summary

Download bootstrap-icons font files when in LOCAL_MODE and create relative parent folders for files if necessary.

In this case it creates **static/css/fonts/**. Not the best since there already is a fonts folder in static, but it doesn't match the path in bootstrap-icons.css. There are of course other solutions to this problem.

### Details

![2024-08-09_20-00](https://github.com/user-attachments/assets/32a9d8ed-9c17-4d35-9b5e-8b5bca53d66e)

### Checks

- [x] Tested changes
