### PR TITLE
added margin to footnote backlinks

### DIFF
--- a/src/wikmd/static/css/wiki.css
+++ b/src/wikmd/static/css/wiki.css
@@ -127,3 +127,7 @@ div.html-integration{
 .mermaid {
     text-align: center;
 }
+
+.footnote-back {
+    margin-left: 0.5em;
+}


### PR DESCRIPTION
### Summary

Hi! This just adds a bit of margin to footnote backlinks :)

before:

![image](https://github.com/user-attachments/assets/b44df42f-85b2-434a-832e-08f67785b66f)

after:

![image](https://github.com/user-attachments/assets/05f45b4a-77f5-4992-a46a-c2777c3cf91f)

### Checks

- [X] Tested changes
