### PR TITLE
Wiki title as variable

### DIFF
--- a/docs/environment variables.md
+++ b/docs/environment variables.md
@@ -20,6 +20,14 @@ export HOMEPAGE=<location>
 export HOMEPAGE_TITLE=<title>
 ```
 
+## Wiki title
+
+The title/name is displayed in the top left corner of the GUI and in the browser tab. It is defaulted to "Wiki". Set this to a unique name to tell multiple instances of wikmd apart.
+
+```
+export WIKI_TITLE="My wiki"
+```
+
 ## Custom port and host
 
 You can change the host and port value by respectively changing the `WIKMD_HOST` and `WIKMD_PORT` variable.

--- a/docs/yaml-configuration.md
+++ b/docs/yaml-configuration.md
@@ -29,6 +29,7 @@ sync_with_remote: 0
 remote_url: ""
 
 wiki_directory: "wiki"
+wiki_title: "Wiki"
 homepage: "homepage.md"
 homepage_title: "homepage"
 images_route: "img"

--- a/src/wikmd/config.py
+++ b/src/wikmd/config.py
@@ -18,6 +18,7 @@ SYNC_WITH_REMOTE_DEFAULT = 0
 REMOTE_URL_DEFAULT = ""
 
 WIKI_DIRECTORY_DEFAULT = "wiki"
+WIKI_TITLE_DEFAULT = "Wiki"
 HOMEPAGE_DEFAULT = "homepage.md"
 HOMEPAGE_TITLE_DEFAULT = "homepage"
 IMAGES_ROUTE_DEFAULT = "img"
@@ -88,6 +89,7 @@ class WikmdConfig:
         self.remote_url = os.getenv("REMOTE_URL") or yaml_config.get("remote_url", REMOTE_URL_DEFAULT)
 
         self.wiki_directory = os.getenv("WIKI_DIRECTORY") or yaml_config.get("wiki_directory", WIKI_DIRECTORY_DEFAULT)
+        self.wiki_title = os.getenv("WIKI_TITLE") or yaml_config.get("wiki_title", WIKI_TITLE_DEFAULT)
         self.homepage = os.getenv("HOMEPAGE") or yaml_config.get("homepage", HOMEPAGE_DEFAULT)
         self.homepage_title = os.getenv("HOMEPAGE_TITLE") or yaml_config.get("homepage_title", HOMEPAGE_TITLE_DEFAULT)
         self.images_route = os.getenv("IMAGES_ROUTE") or yaml_config.get("images_route", IMAGES_ROUTE_DEFAULT)

--- a/src/wikmd/templates/base.html
+++ b/src/wikmd/templates/base.html
@@ -39,14 +39,14 @@
         }
     </style>
 
-    <title>Wiki</title>
+    <title>{{ system.wiki_title }}</title>
 </head>
 
 <body>
     <!-- Navbar top -->
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark sticky-top">
         <div class="container-fluid mx-2">
-            <a class="navbar-brand" href="/">Wiki</a>
+            <a class="navbar-brand" href="/">{{ system.wiki_title }}</a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
                     aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/src/wikmd/wiki.py
+++ b/src/wikmd/wiki.py
@@ -72,7 +72,8 @@ SYSTEM_SETTINGS = {
     "darktheme": False,
     "listsortMTime": False,
     "web_deps": web_deps,
-    "plugins": plugins
+    "plugins": plugins,
+    "wiki_title": cfg.wiki_title
 }
 
 def process(content: str, page_name: str):

--- a/src/wikmd/wiki.py
+++ b/src/wikmd/wiki.py
@@ -121,8 +121,14 @@ def ensure_page_can_be_created(page, page_name):
             app.logger.info(f"No page name provided.")
 
     content = process(request.form['CT'], page_name)
-    return render_template("new.html", content=content, title=page, upload_path=cfg.images_route,
-                           image_allowed_mime=cfg.image_allowed_mime, system=SYSTEM_SETTINGS)
+    return render_template(
+        "new.html",
+        content=content,
+        title=page,
+        upload_path=cfg.images_route,
+        image_allowed_mime=cfg.image_allowed_mime,
+        system=SYSTEM_SETTINGS
+    )
 
 
 def save(page_name):
@@ -160,7 +166,7 @@ def search(search_term: str, page: int):
         current_page=page,
         suggestions=suggestions,
         results=results,
-        system=SYSTEM_SETTINGS,
+        system=SYSTEM_SETTINGS
     )
 
 
@@ -267,7 +273,12 @@ def list_wiki(folderpath):
     else:
         files_list.sort(key=lambda x: (str(x["url"]).casefold()))
 
-    return render_template('list_files.html', list=files_list, folder=folderpath, system=SYSTEM_SETTINGS)
+    return render_template(
+        'list_files.html',
+        list=files_list,
+        folder=folderpath,
+        system=SYSTEM_SETTINGS
+    )
 
 
 @app.route('/search', methods=['GET'])
@@ -290,9 +301,13 @@ def file_page(file_page):
         html_content, mod = get_html(file_page)
 
         return render_template(
-            'content.html', title=file_page, folder="", info=html_content, modif=mod,
+            'content.html',
+            title=file_page,
+            folder="",
+            info=html_content,
+            modif=mod,
             system=SYSTEM_SETTINGS
-    )
+        )
     except FileNotFoundError as e:
         app.logger.info(e)
         return redirect("/add_new?page=" + file_page)
@@ -332,8 +347,13 @@ def add_new():
         page_name = request.args.get("page")
         if page_name is None:
             page_name = ""
-        return render_template('new.html', upload_path=cfg.images_route,
-                               image_allowed_mime=cfg.image_allowed_mime, title=page_name, system=SYSTEM_SETTINGS)
+        return render_template(
+            'new.html',
+            upload_path=cfg.images_route,
+            image_allowed_mime=cfg.image_allowed_mime,
+            title=page_name,
+            system=SYSTEM_SETTINGS
+        )
 
 
 @app.route('/edit/homepage', methods=['POST', 'GET'])
@@ -354,8 +374,14 @@ def edit_homepage():
         with open(os.path.join(cfg.wiki_directory, cfg.homepage), 'r', encoding="utf-8", errors='ignore') as f:
 
             content = f.read()
-        return render_template("new.html", content=content, title=cfg.homepage_title, upload_path=cfg.images_route,
-                               image_allowed_mime=cfg.image_allowed_mime, system=SYSTEM_SETTINGS)
+        return render_template(
+            "new.html",
+            content=content,
+            title=cfg.homepage_title,
+            upload_path=cfg.images_route,
+            image_allowed_mime=cfg.image_allowed_mime,
+            system=SYSTEM_SETTINGS
+        )
 
 
 @app.route('/remove/<path:page>', methods=['GET'])
@@ -397,12 +423,24 @@ def edit(page):
         if exists(filename):
             with open(filename, 'r', encoding="utf-8", errors='ignore') as f:
                 content = f.read()
-            return render_template("new.html", content=content, title=page, upload_path=cfg.images_route,
-                                   image_allowed_mime=cfg.image_allowed_mime, system=SYSTEM_SETTINGS)
+            return render_template(
+                "new.html",
+                content=content,
+                title=page,
+                upload_path=cfg.images_route,
+                image_allowed_mime=cfg.image_allowed_mime,
+                system=SYSTEM_SETTINGS
+            )
         else:
             logger.error(f"{filename} does not exists. Creating a new one.")
-            return render_template("new.html", content="", title=page, upload_path=cfg.images_route,
-                                   image_allowed_mime=cfg.image_allowed_mime, system=SYSTEM_SETTINGS)
+            return render_template(
+                "new.html",
+                content="",
+                title=page,
+                upload_path=cfg.images_route,
+                image_allowed_mime=cfg.image_allowed_mime,
+                system=SYSTEM_SETTINGS
+            )
 
 
 @app.route(os.path.join("/", cfg.images_route), methods=['POST', 'DELETE'])

--- a/src/wikmd/wikmd-config.yaml
+++ b/src/wikmd/wikmd-config.yaml
@@ -13,6 +13,7 @@ sync_with_remote: 0
 remote_url: ""
 
 wiki_directory: "wiki"
+wiki_title: "Wiki"
 homepage: "homepage.md"
 homepage_title: "homepage"
 images_route: "img"


### PR DESCRIPTION
### Summary

Changes from hardcoded "Wiki" as title in head and navbar to a variable.

It would be cool to have a prefix in **<title>** depending on which page is displayed. E.g. "homepage | Wiki".  I could have a look at figuring it out but I'm not sure what would be a clean way to implement it.

### Details

- Adds variable WIKI_TITLE.
- Defaults to "Wiki".
- Passes it in all render_template() calls. 

### Checks

- [X] In case of new feature, add short overview in ```docs/<corresponding file>``` 
- [X] Tested changes
