### PR TITLE
Set container stop signal to sigint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,5 +61,8 @@ WORKDIR /
 # Expose the port that the application listens on.
 EXPOSE 5000
 
+# Flask expects sigint as stop signal
+STOPSIGNAL SIGINT
+
 # Run the application.
 CMD ["python", "-m", "wikmd.wiki"]


### PR DESCRIPTION
### Summary

 Fixes timeout when stopping a wikmd container by changing the default container stop signal to SIGINT.

### Details

The default signal to stop containers in Docker and Podman is SIGTERM, but flask apparently expects SIGINT. So stopping a container causes a timeout until Docker resorts to SIGKILL, which finally stops the container.

```
# Current container
$ time podman stop wiki
WARN[0010] StopSignal SIGTERM failed to stop container wiki in 10 seconds, resorting to SIGKILL 
wiki

real	0m10.265s

# STOPSIGNAL SIGINT
$ time podman stop wiki
wiki

real	0m0.195s
```

### Checks

- [X] Tested changes
