### PR TITLE
Fixed issue on OSX safari. Regular expressions for alers did not match…

### DIFF
--- a/src/wikmd/plugins/alerts/alerts.py
+++ b/src/wikmd/plugins/alerts/alerts.py
@@ -39,10 +39,10 @@ class Plugin:
 
 
         result = file
-        result = re.sub(r"(?i)(\<p)()(\>)\[\[warning\]\](.*)\<\/p\>", r"<div class='alert alert-warning d-flex'\3"+warning_icon+r" <a>\4</a></div>", result)
-        result = re.sub(r"(?i)(\<p)()(\>)\[\[info\]\](.*)\<\/p\>", r"<div class='alert alert-info d-flex'\3"+info_icon+r" <a>\4</a></div>", result)
-        result = re.sub(r"(?i)(\<p)()(\>)\[\[danger\]\](.*)\<\/p\>", r"<div class='alert alert-danger d-flex'\3"+danger_icon+r" <a>\4</a></div>", result)
-        result = re.sub(r"(?i)(\<p)()(\>)\[\[success\]\](.*)\<\/p\>", r"<div class='alert alert-success d-flex'\3"+success_icon+r" <a>\4</a></div>", result)
+        result = re.sub(r"(?si)(\<p)()(\>)\[\[warning\]\](.*?)\<\/p\>", r"<div class='alert alert-warning d-flex'\3"+warning_icon+r" <a>\4</a></div>", result)
+        result = re.sub(r"(?si)(\<p)()(\>)\[\[info\]\](.*?)\<\/p\>", r"<div class='alert alert-info d-flex'\3"+info_icon+r" <a>\4</a></div>", result)
+        result = re.sub(r"(?si)(\<p)()(\>)\[\[danger\]\](.*?)\<\/p\>", r"<div class='alert alert-danger d-flex'\3"+danger_icon+r" <a>\4</a></div>", result)
+        result = re.sub(r"(?si)(\<p)()(\>)\[\[success\]\](.*?)\<\/p\>", r"<div class='alert alert-success d-flex'\3"+success_icon+r" <a>\4</a></div>", result)
 
         return result
 


### PR DESCRIPTION
Summary:
Fixed regular expression for Alert plugin: r"(?si)(\<p)()(\>)\[\[warning\]\](.*?)\<\/p\>"

Problem:
On my setup the regular expression for a paragraph did not match causing.
This was evident because the "[[warning]]" tag still showed on the generated HTML pages.

Cause:
Problem seems to be that the regular expression does not match strings with "newline" characters.

Solution:
Changed regular expression:
 - (?s) --> (?si) to match new line character too
 - (.*) --> (.*?) to prevent greedy matching 

