### PR TITLE
fix: prevent open redirect in toggle-darktheme endpoint

### DIFF
--- a/src/wikmd/wiki.py
+++ b/src/wikmd/wiki.py
@@ -526,7 +526,11 @@ def display_image(image_name):
 @app.route('/toggle-darktheme/', methods=['GET'])
 def toggle_darktheme():
     SYSTEM_SETTINGS['darktheme'] = not SYSTEM_SETTINGS['darktheme']
-    return redirect(request.args.get("return", "/"))  # redirect to the same page URL
+    # Prevent open redirect: only allow relative paths
+    return_url = request.args.get("return", "/")
+    if return_url.startswith("//") or "://" in return_url:
+        return_url = "/"
+    return redirect(return_url)
 
 
 @app.route('/toggle-sorting/', methods=['GET'])


### PR DESCRIPTION
## Summary

Prevent open redirect in the `toggle-darktheme` endpoint by validating the `return` parameter.

## Problem

The dark theme toggle redirects to a user-supplied URL without validation:

```python
return redirect(request.args.get("return", "/"))
```

An attacker can craft: `/toggle-darktheme/?return=https://evil.com` to redirect users to external sites.

## Fix

Validate the return URL is a relative path:

```python
return_url = request.args.get("return", "/")
if return_url.startswith("//") or "://" in return_url:
    return_url = "/"
return redirect(return_url)
```

## Impact

- **Type**: Open Redirect (CWE-601)
- **Affected endpoint**: `GET /toggle-darktheme/`
- **OWASP**: A01:2021 — Broken Access Control